### PR TITLE
Demonstrates uses of RestTemplate via accessing a third party API:

### DIFF
--- a/src/main/java/com/oreilly/demo/json/Assignment.java
+++ b/src/main/java/com/oreilly/demo/json/Assignment.java
@@ -1,0 +1,37 @@
+package com.oreilly.demo.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Assignment {
+
+	@JsonProperty("craft")
+	private String craft;
+
+	@JsonProperty("name")
+	private String name;
+
+	public void setCraft(String craft){
+		this.craft = craft;
+	}
+
+	public String getCraft(){
+		return craft;
+	}
+
+	public void setName(String name){
+		this.name = name;
+	}
+
+	public String getName(){
+		return name;
+	}
+
+	@Override
+ 	public String toString(){
+		return 
+			"Assignment{" +
+			"craft = '" + craft + '\'' + 
+			",name = '" + name + '\'' + 
+			"}";
+		}
+}

--- a/src/main/java/com/oreilly/demo/json/AstroResult.java
+++ b/src/main/java/com/oreilly/demo/json/AstroResult.java
@@ -1,0 +1,50 @@
+package com.oreilly.demo.json;
+
+import java.util.List;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AstroResult{
+
+	@JsonProperty("number")
+	private int number;
+
+	@JsonProperty("message")
+	private String message;
+
+	@JsonProperty("people")
+	private List<Assignment> people;
+
+	public void setNumber(int number){
+		this.number = number;
+	}
+
+	public int getNumber(){
+		return number;
+	}
+
+	public void setMessage(String message){
+		this.message = message;
+	}
+
+	public String getMessage(){
+		return message;
+	}
+
+	public void setPeople(List<Assignment> people){
+		this.people = people;
+	}
+
+	public List<Assignment> getPeople(){
+		return people;
+	}
+
+	@Override
+ 	public String toString(){
+		return 
+			"AstroResult{" + 
+			"number = '" + number + '\'' + 
+			",message = '" + message + '\'' + 
+			",people = '" + people + '\'' + 
+			"}";
+		}
+}

--- a/src/main/java/com/oreilly/demo/services/AstroService.java
+++ b/src/main/java/com/oreilly/demo/services/AstroService.java
@@ -1,0 +1,26 @@
+package com.oreilly.demo.services;
+
+import com.oreilly.demo.json.AstroResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class AstroService {
+
+   private final RestTemplate template;
+
+   @Autowired
+   public AstroService(RestTemplateBuilder rtBuilder) {
+
+      template = rtBuilder.build();
+   }
+
+   public AstroResult getAstronauts() {
+
+      String url = "http://api.open-notify.org/astros.json";
+      return template.getForObject(url, AstroResult.class);
+
+   }
+}

--- a/src/test/java/com/oreilly/demo/services/AstroServiceTest.java
+++ b/src/test/java/com/oreilly/demo/services/AstroServiceTest.java
@@ -1,0 +1,32 @@
+package com.oreilly.demo.services;
+
+import com.oreilly.demo.json.Assignment;
+import com.oreilly.demo.json.AstroResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+@SpringBootTest
+public class AstroServiceTest {
+
+   @Autowired
+   private AstroService service;
+
+   @Test
+   public void getAstronauts() {
+
+      AstroResult result = service.getAstronauts();
+      int number = result.getNumber();
+      List<Assignment> people = result.getPeople();
+      System.out.println("There are " + number + " people in space");
+      result.getPeople().forEach(System.out::println);
+      assertAll(
+            () -> assertTrue(number >= 0),
+            () -> assertEquals(number, people.size())
+      );
+   }
+}


### PR DESCRIPTION
- Added two classes : json.Assignment & json.AstroResult to hold the response from third party API - http://api.open-notify.org/astros.json
- Added a class : service.AstroService in which we use a RestTemplateBuilder to build a RestTemplate and autowire into instance variable - template. This class is also annotated with @Service which basically makes this service class a Bean managed by Spring. This is equivalent to @Component but generally used for classes at service layer where your business logic lies
- Added services.AstroServiceTest JUnit test to verify the service and domain objects created to consume the response of the third party URL.