### PR TITLE
Demonstrates use of WebClient from Spring's reactive package to acces…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/oreilly/demo/services/AstroService.java
+++ b/src/main/java/com/oreilly/demo/services/AstroService.java
@@ -3,24 +3,40 @@ package com.oreilly.demo.services;
 import com.oreilly.demo.json.AstroResult;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
 
 @Service
 public class AstroService {
 
    private final RestTemplate template;
+   private final WebClient webClient;
 
    @Autowired
-   public AstroService(RestTemplateBuilder rtBuilder) {
+   public AstroService(RestTemplateBuilder rtBuilder, WebClient.Builder wcBuilder) {
 
       template = rtBuilder.build();
+      webClient = wcBuilder.baseUrl("http://api.open-notify.org").build();
    }
 
-   public AstroResult getAstronauts() {
+   public AstroResult getAstronautsRT() {
 
       String url = "http://api.open-notify.org/astros.json";
       return template.getForObject(url, AstroResult.class);
 
+   }
+
+   public AstroResult getAstronautsWC() {
+
+      return webClient.get()
+                      .uri("/astros.json")
+                      .accept(MediaType.APPLICATION_JSON)
+                      .retrieve()
+                      .bodyToMono(AstroResult.class)
+                      .block(Duration.ofSeconds(2));
    }
 }

--- a/src/test/java/com/oreilly/demo/services/AstroServiceTest.java
+++ b/src/test/java/com/oreilly/demo/services/AstroServiceTest.java
@@ -17,9 +17,23 @@ public class AstroServiceTest {
    private AstroService service;
 
    @Test
-   public void getAstronauts() {
+   public void getAstronautsRT() {
 
-      AstroResult result = service.getAstronauts();
+      AstroResult result = service.getAstronautsRT();
+      int number = result.getNumber();
+      List<Assignment> people = result.getPeople();
+      System.out.println("There are " + number + " people in space");
+      result.getPeople().forEach(System.out::println);
+      assertAll(
+            () -> assertTrue(number >= 0),
+            () -> assertEquals(number, people.size())
+      );
+   }
+
+   @Test
+   public void getAstronautsWC() {
+
+      AstroResult result = service.getAstronautsWC();
       int number = result.getNumber();
       List<Assignment> people = result.getPeople();
       System.out.println("There are " + number + " people in space");


### PR DESCRIPTION
…s thrid party API:

- Added dependency for spring-boot-starter-webflux that contains WebClient and relevant class and/or interface definitions.
- Added a new method in services.AstroService class to get astronauts using WebClient. In order to access third party API using web client, a new instance variable of type WebClient is added and to assign it with an instance of web client, a webclient builder is inroduced to its constructor.
- Added a JUnit test to verify that the WebClient's way of accessing third party API is working fine.
- Note that get() method of web client is used with uri() chain call to specify complete path to access and used retrieve() to specify how to extract the response. The call to bodyToMono() is used to decode the response into target entity type. A call to block() method is also used to make your call wait for response from the API for specified duration.