### PR TITLE
Demonstrate use of application.properties file to customize the beans…

### DIFF
--- a/src/main/java/com/oreilly/demo/json/Geometry.java
+++ b/src/main/java/com/oreilly/demo/json/Geometry.java
@@ -1,0 +1,25 @@
+package com.oreilly.demo.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Geometry{
+
+	@JsonProperty("location")
+	private Location location;
+
+	public void setLocation(Location location){
+		this.location = location;
+	}
+
+	public Location getLocation(){
+		return location;
+	}
+
+	@Override
+ 	public String toString(){
+		return 
+			"Geometry{" + 
+			"location = '" + location + '\'' + 
+			"}";
+		}
+}

--- a/src/main/java/com/oreilly/demo/json/Location.java
+++ b/src/main/java/com/oreilly/demo/json/Location.java
@@ -1,0 +1,37 @@
+package com.oreilly.demo.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Location{
+
+	@JsonProperty("lng")
+	private double lng;
+
+	@JsonProperty("lat")
+	private double lat;
+
+	public void setLng(double lng){
+		this.lng = lng;
+	}
+
+	public double getLng(){
+		return lng;
+	}
+
+	public void setLat(double lat){
+		this.lat = lat;
+	}
+
+	public double getLat(){
+		return lat;
+	}
+
+	@Override
+ 	public String toString(){
+		return 
+			"Location{" + 
+			"lng = '" + lng + '\'' + 
+			",lat = '" + lat + '\'' + 
+			"}";
+		}
+}

--- a/src/main/java/com/oreilly/demo/json/Response.java
+++ b/src/main/java/com/oreilly/demo/json/Response.java
@@ -1,0 +1,38 @@
+package com.oreilly.demo.json;
+
+import java.util.List;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class 	Response{
+
+	@JsonProperty("results")
+	private List<Result> results;
+
+	@JsonProperty("status")
+	private String status;
+
+	public void setResults(List<Result> results){
+		this.results = results;
+	}
+
+	public List<Result> getResults(){
+		return results;
+	}
+
+	public void setStatus(String status){
+		this.status = status;
+	}
+
+	public String getStatus(){
+		return status;
+	}
+
+	@Override
+ 	public String toString(){
+		return 
+			"Response{" + 
+			"results = '" + results + '\'' + 
+			",status = '" + status + '\'' + 
+			"}";
+		}
+}

--- a/src/main/java/com/oreilly/demo/json/Result.java
+++ b/src/main/java/com/oreilly/demo/json/Result.java
@@ -1,0 +1,37 @@
+package com.oreilly.demo.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Result {
+
+
+	private String formattedAddress;
+
+	@JsonProperty("geometry")
+	private Geometry geometry;
+
+	public void setFormattedAddress(String formattedAddress){
+		this.formattedAddress = formattedAddress;
+	}
+
+	public String getFormattedAddress(){
+		return formattedAddress;
+	}
+
+	public void setGeometry(Geometry geometry){
+		this.geometry = geometry;
+	}
+
+	public Geometry getGeometry(){
+		return geometry;
+	}
+
+	@Override
+ 	public String toString(){
+		return 
+			"Result{" +
+			"formatted_address = '" + formattedAddress + '\'' + 
+			",geometry = '" + geometry + '\'' + 
+			"}";
+		}
+}

--- a/src/main/java/com/oreilly/demo/json/Site.java
+++ b/src/main/java/com/oreilly/demo/json/Site.java
@@ -1,0 +1,38 @@
+package com.oreilly.demo.json;
+
+public class Site {
+
+   private Integer id;
+   private final String address;
+   private final double latitude;
+   private final double langitue;
+
+   public Site(String address, double latitude, double langitue) {
+
+      this.address = address;
+      this.latitude = latitude;
+      this.langitue = langitue;
+   }
+
+   public String getAddress() {
+
+      return address;
+   }
+
+   public double getLatitude() {
+
+      return latitude;
+   }
+
+   public double getLangitue() {
+
+      return langitue;
+   }
+
+   @Override
+   public String toString() {
+
+      return "Site{" + "id=" + id + ", address='" + address + '\'' + ", latitude=" + latitude + ", langitue=" + langitue
+            + '}';
+   }
+}

--- a/src/main/java/com/oreilly/demo/services/GeoCoderService.java
+++ b/src/main/java/com/oreilly/demo/services/GeoCoderService.java
@@ -1,0 +1,47 @@
+package com.oreilly.demo.services;
+
+import com.oreilly.demo.json.Response;
+import com.oreilly.demo.json.Site;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+public class GeoCoderService {
+
+   private final WebClient client;
+
+   private final String KEY = "AIzaSyDw_d6dfxDEI7MAvqfGXEIsEMwjC1PWRno";
+
+   @Autowired
+   public GeoCoderService(WebClient.Builder wcBuilder) {
+
+      this.client = wcBuilder.baseUrl("https://maps.googleapis.com").build();
+   }
+
+   public Site getLatLang(String... address) {
+      String encoded = Stream.of(address)
+            .map(s -> URLEncoder.encode(s, StandardCharsets.UTF_8))
+            .collect(Collectors.joining(","));
+      String path = "/maps/api/geocode/json";
+      Response response = client.get()
+            .uri(uriBuilder -> uriBuilder.path(path)
+               .queryParam("address", encoded)
+               .queryParam("key", KEY)
+               .build()
+            )
+            .retrieve()
+            .bodyToMono(Response.class)
+            .block(Duration.ofSeconds(2));
+      return new Site(response.getResults().get(0).getFormattedAddress(),
+               response.getResults().get(0).getGeometry().getLocation().getLat(),
+               response.getResults().get(0).getGeometry().getLocation().getLng()
+            );
+   }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 logging.level.web=debug
+spring.jackson.property-naming-strategy=SNAKE_CASE

--- a/src/test/java/com/oreilly/demo/services/GeoCoderServiceTest.java
+++ b/src/test/java/com/oreilly/demo/services/GeoCoderServiceTest.java
@@ -1,0 +1,42 @@
+package com.oreilly.demo.services;
+
+import com.oreilly.demo.json.Site;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class GeoCoderServiceTest {
+
+   private final Logger logger = LoggerFactory.getLogger(GeoCoderServiceTest.class);
+
+   @Autowired
+   private GeoCoderService service;
+
+   @Test
+   void getLatLangWithoutStreet() {
+
+      Site site = service.getLatLang("Boston", "MA");
+      logger.info(site.toString());
+      assertAll(
+            () -> assertEquals(42.36, site.getLatitude(), 0.01),
+            () -> assertEquals(-71.06, site.getLangitue(), 0.01)
+      );
+   }
+
+   @Test
+   void getLatLangeWithStreet() {
+
+      Site site = service.getLatLang("1600 Ampithetre Parkway", "Mountain View", "CA");
+      logger.info(site.toString());
+      assertAll(
+            () -> assertEquals(37.42, site.getLatitude(), 0.01),
+            () -> assertEquals(-122.08, site.getLangitue(), 0.01)
+      );
+
+   }
+}


### PR DESCRIPTION
… in the application context:

- Add required Java class files - Location, Geometry, Result & Response classes.
- Add a Java class file to hold only relevant fields - Site class.
- Add a service called GeoCoderService that uses WebClient to connect to geocoding api and fetch the results. Use URLEncoding class of Java to frame URI to hit in the required format and use reactive retrieve() method of WebClient to fetch the result.
- Add a test class called GeoCoderServiceTest to test this service using JUnit 5. Note the use of Logger instance of org.slf4j.Logger class used to print log outputs of running tests.
- By default, address field of Site object did not have any value after response from URI fetch has been deserialized as the key in geocode API was formatted_address where as instance variable used in Result class to hold its value was formattedAddress which were not matching. We used spring.jackson.property-naming-strategy parameter in application.properties file and set its value to SNAKE_CASE to customize property naming in beans across Spring application to what is expected.